### PR TITLE
Magic router: .route implementation, methods chaining, conditional route types

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,5 +21,5 @@ services:
 
 volumes:
   mongodb_typescript_backend_toolkit:
-    external: true
+    # external: true
   redis:

--- a/src/openapi/magic-router.ts
+++ b/src/openapi/magic-router.ts
@@ -61,11 +61,12 @@ export type RequestAndResponseType = {
 export class MagicRouter<PathSet extends boolean = false> {
   private router: Router;
   private rootRoute: string;
-  private currentPath: string | null = null;
+  private currentPath?: string;
 
-  constructor(rootRoute: string) {
+  constructor(rootRoute: string, currentPath?: string) {
     this.router = Router();
     this.rootRoute = rootRoute;
+    this.currentPath = currentPath;
   }
 
   private getPath(path: string) {
@@ -201,7 +202,8 @@ export class MagicRouter<PathSet extends boolean = false> {
   }
 
   public get(...args: MagicRoutePType<PathSet>): MagicRouteRType<PathSet> {
-    if (this.currentPath !== null) {
+    if (this.currentPath) {
+      console.log(this.currentPath);
       const [reqAndRes, ...handlers] = args as [
         RequestAndResponseType,
         ...MagicMiddleware[],
@@ -219,7 +221,7 @@ export class MagicRouter<PathSet extends boolean = false> {
   }
 
   public post(...args: MagicRoutePType<PathSet>): MagicRouteRType<PathSet> {
-    if (this.currentPath !== null) {
+    if (this.currentPath) {
       const [reqAndRes, ...handlers] = args as [
         RequestAndResponseType,
         ...MagicMiddleware[],
@@ -237,7 +239,7 @@ export class MagicRouter<PathSet extends boolean = false> {
   }
 
   public delete(...args: MagicRoutePType<PathSet>): MagicRouteRType<PathSet> {
-    if (this.currentPath !== null) {
+    if (this.currentPath) {
       const [reqAndRes, ...handlers] = args as [
         RequestAndResponseType,
         ...MagicMiddleware[],
@@ -255,7 +257,7 @@ export class MagicRouter<PathSet extends boolean = false> {
   }
 
   public patch(...args: MagicRoutePType<PathSet>): MagicRouteRType<PathSet> {
-    if (this.currentPath !== null) {
+    if (this.currentPath) {
       const [reqAndRes, ...handlers] = args as [
         RequestAndResponseType,
         ...MagicMiddleware[],
@@ -273,7 +275,7 @@ export class MagicRouter<PathSet extends boolean = false> {
   }
 
   public put(...args: MagicRoutePType<PathSet>): MagicRouteRType<PathSet> {
-    if (this.currentPath !== null) {
+    if (this.currentPath) {
       const [reqAndRes, ...handlers] = args as [
         RequestAndResponseType,
         ...MagicMiddleware[],
@@ -295,8 +297,7 @@ export class MagicRouter<PathSet extends boolean = false> {
   }
 
   public route(path: string): MagicRouteRType<true> {
-    this.currentPath = path;
-    return this as MagicRouteRType<true>;
+    return new MagicRouter<true>(this.rootRoute, path);
   }
 
   // Method to get the router instance

--- a/src/openapi/magic-router.ts
+++ b/src/openapi/magic-router.ts
@@ -36,15 +36,32 @@ export type MaybePromise = void | Promise<void>;
 export type RequestAny = Request<IDontKnow, IDontKnow, IDontKnow, IDontKnow>;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ResponseAny = Response<IDontKnow, Record<string, any>>;
+export type MagicRoutePType<PathSet extends boolean> = PathSet extends true
+  ? [reqAndRes: RequestAndResponseType, ...handlers: MagicMiddleware[]]
+  : [
+      path: string,
+      reqAndRes: RequestAndResponseType,
+      ...handlers: MagicMiddleware[],
+    ];
+export type MagicRouteRType<PathSet extends boolean> = Omit<
+  MagicRouter<PathSet>,
+  'route' | 'getRouter' | 'use'
+>;
+export type MagicMiddleware = (
+  req: RequestAny,
+  res: ResponseAny,
+  next?: NextFunction,
+) => MaybePromise;
 
 export type RequestAndResponseType = {
   requestType?: RequestZodSchemaType;
   responseModel?: ZodTypeAny;
 };
 
-export class MagicRouter {
+export class MagicRouter<PathSet extends boolean = false> {
   private router: Router;
   private rootRoute: string;
+  private currentPath: string | null = null;
 
   constructor(rootRoute: string) {
     this.router = Router();
@@ -59,9 +76,7 @@ export class MagicRouter {
     method: Method,
     path: string,
     requestAndResponseType: RequestAndResponseType,
-    ...middlewares: Array<
-      (req: RequestAny, res: ResponseAny, next?: NextFunction) => MaybePromise
-    >
+    ...middlewares: Array<MagicMiddleware>
   ): void {
     const bodyType = requestAndResponseType.requestType?.body;
     const paramsType = requestAndResponseType.requestType?.params;
@@ -185,57 +200,103 @@ export class MagicRouter {
     }
   }
 
-  public get(
-    path: string,
-    requestAndResponseType: RequestAndResponseType,
-    ...middlewares: Array<
-      (req: RequestAny, res: ResponseAny, next?: NextFunction) => MaybePromise
-    >
-  ): void {
-    this.wrapper('get', path, requestAndResponseType, ...middlewares);
+  public get(...args: MagicRoutePType<PathSet>): MagicRouteRType<PathSet> {
+    if (this.currentPath !== null) {
+      const [reqAndRes, ...handlers] = args as [
+        RequestAndResponseType,
+        ...MagicMiddleware[],
+      ];
+      this.wrapper('get', this.currentPath, reqAndRes, ...handlers);
+    } else {
+      const [path, reqAndRes, ...handlers] = args as [
+        string,
+        RequestAndResponseType,
+        ...MagicMiddleware[],
+      ];
+      this.wrapper('get', path, reqAndRes, ...handlers);
+    }
+    return this;
   }
 
-  public post(
-    path: string,
-    requestAndResponseType: RequestAndResponseType,
-    ...middlewares: Array<
-      (req: RequestAny, res: ResponseAny, next?: NextFunction) => MaybePromise
-    >
-  ): void {
-    this.wrapper('post', path, requestAndResponseType, ...middlewares);
+  public post(...args: MagicRoutePType<PathSet>): MagicRouteRType<PathSet> {
+    if (this.currentPath !== null) {
+      const [reqAndRes, ...handlers] = args as [
+        RequestAndResponseType,
+        ...MagicMiddleware[],
+      ];
+      this.wrapper('post', this.currentPath, reqAndRes, ...handlers);
+    } else {
+      const [path, reqAndRes, ...handlers] = args as [
+        string,
+        RequestAndResponseType,
+        ...MagicMiddleware[],
+      ];
+      this.wrapper('post', path, reqAndRes, ...handlers);
+    }
+    return this;
   }
 
-  public delete(
-    path: string,
-    requestAndResponseType: RequestAndResponseType,
-    ...middlewares: Array<
-      (req: RequestAny, res: ResponseAny, next?: NextFunction) => MaybePromise
-    >
-  ): void {
-    this.wrapper('delete', path, requestAndResponseType, ...middlewares);
+  public delete(...args: MagicRoutePType<PathSet>): MagicRouteRType<PathSet> {
+    if (this.currentPath !== null) {
+      const [reqAndRes, ...handlers] = args as [
+        RequestAndResponseType,
+        ...MagicMiddleware[],
+      ];
+      this.wrapper('delete', this.currentPath, reqAndRes, ...handlers);
+    } else {
+      const [path, reqAndRes, ...handlers] = args as [
+        string,
+        RequestAndResponseType,
+        ...MagicMiddleware[],
+      ];
+      this.wrapper('delete', path, reqAndRes, ...handlers);
+    }
+    return this;
   }
 
-  public patch(
-    path: string,
-    requestAndResponseType: RequestAndResponseType,
-    ...middlewares: Array<
-      (req: RequestAny, res: ResponseAny, next?: NextFunction) => MaybePromise
-    >
-  ): void {
-    this.wrapper('patch', path, requestAndResponseType, ...middlewares);
+  public patch(...args: MagicRoutePType<PathSet>): MagicRouteRType<PathSet> {
+    if (this.currentPath !== null) {
+      const [reqAndRes, ...handlers] = args as [
+        RequestAndResponseType,
+        ...MagicMiddleware[],
+      ];
+      this.wrapper('patch', this.currentPath, reqAndRes, ...handlers);
+    } else {
+      const [path, reqAndRes, ...handlers] = args as [
+        string,
+        RequestAndResponseType,
+        ...MagicMiddleware[],
+      ];
+      this.wrapper('patch', path, reqAndRes, ...handlers);
+    }
+    return this;
   }
 
-  public put(
-    path: string,
-    requestAndResponseType: RequestAndResponseType,
-    ...middlewares: Array<
-      (req: RequestAny, res: ResponseAny, next?: NextFunction) => MaybePromise
-    >
-  ): void {
-    this.wrapper('put', path, requestAndResponseType, ...middlewares);
+  public put(...args: MagicRoutePType<PathSet>): MagicRouteRType<PathSet> {
+    if (this.currentPath !== null) {
+      const [reqAndRes, ...handlers] = args as [
+        RequestAndResponseType,
+        ...MagicMiddleware[],
+      ];
+      this.wrapper('put', this.currentPath, reqAndRes, ...handlers);
+    } else {
+      const [path, reqAndRes, ...handlers] = args as [
+        string,
+        RequestAndResponseType,
+        ...MagicMiddleware[],
+      ];
+      this.wrapper('put', path, reqAndRes, ...handlers);
+    }
+    return this;
   }
+
   public use(...args: Parameters<Router['use']>): void {
     this.router.use(...args);
+  }
+
+  public route(path: string): MagicRouteRType<true> {
+    this.currentPath = path;
+    return this as MagicRouteRType<true>;
   }
 
   // Method to get the router instance

--- a/src/openapi/magic-router.ts
+++ b/src/openapi/magic-router.ts
@@ -36,10 +36,11 @@ export type MaybePromise = void | Promise<void>;
 export type RequestAny = Request<IDontKnow, IDontKnow, IDontKnow, IDontKnow>;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ResponseAny = Response<IDontKnow, Record<string, any>>;
+export type MagicPathType = `/${string}`;
 export type MagicRoutePType<PathSet extends boolean> = PathSet extends true
   ? [reqAndRes: RequestAndResponseType, ...handlers: MagicMiddleware[]]
   : [
-      path: string,
+      path: MagicPathType,
       reqAndRes: RequestAndResponseType,
       ...handlers: MagicMiddleware[],
     ];
@@ -61,9 +62,9 @@ export type RequestAndResponseType = {
 export class MagicRouter<PathSet extends boolean = false> {
   private router: Router;
   private rootRoute: string;
-  private currentPath?: string;
+  private currentPath?: MagicPathType;
 
-  constructor(rootRoute: string, currentPath?: string) {
+  constructor(rootRoute: string, currentPath?: MagicPathType) {
     this.router = Router();
     this.rootRoute = rootRoute;
     this.currentPath = currentPath;
@@ -75,7 +76,7 @@ export class MagicRouter<PathSet extends boolean = false> {
 
   private wrapper(
     method: Method,
-    path: string,
+    path: MagicPathType,
     requestAndResponseType: RequestAndResponseType,
     ...middlewares: Array<MagicMiddleware>
   ): void {
@@ -202,102 +203,49 @@ export class MagicRouter<PathSet extends boolean = false> {
   }
 
   public get(...args: MagicRoutePType<PathSet>): MagicRouteRType<PathSet> {
-    if (this.currentPath) {
-      console.log(this.currentPath);
-      const [reqAndRes, ...handlers] = args as [
-        RequestAndResponseType,
-        ...MagicMiddleware[],
-      ];
-      this.wrapper('get', this.currentPath, reqAndRes, ...handlers);
-    } else {
-      const [path, reqAndRes, ...handlers] = args as [
-        string,
-        RequestAndResponseType,
-        ...MagicMiddleware[],
-      ];
-      this.wrapper('get', path, reqAndRes, ...handlers);
-    }
-    return this;
+    return this.routeHandler('get', ...args);
   }
 
   public post(...args: MagicRoutePType<PathSet>): MagicRouteRType<PathSet> {
-    if (this.currentPath) {
-      const [reqAndRes, ...handlers] = args as [
-        RequestAndResponseType,
-        ...MagicMiddleware[],
-      ];
-      this.wrapper('post', this.currentPath, reqAndRes, ...handlers);
-    } else {
-      const [path, reqAndRes, ...handlers] = args as [
-        string,
-        RequestAndResponseType,
-        ...MagicMiddleware[],
-      ];
-      this.wrapper('post', path, reqAndRes, ...handlers);
-    }
-    return this;
+    return this.routeHandler('post', ...args);
   }
 
   public delete(...args: MagicRoutePType<PathSet>): MagicRouteRType<PathSet> {
-    if (this.currentPath) {
-      const [reqAndRes, ...handlers] = args as [
-        RequestAndResponseType,
-        ...MagicMiddleware[],
-      ];
-      this.wrapper('delete', this.currentPath, reqAndRes, ...handlers);
-    } else {
-      const [path, reqAndRes, ...handlers] = args as [
-        string,
-        RequestAndResponseType,
-        ...MagicMiddleware[],
-      ];
-      this.wrapper('delete', path, reqAndRes, ...handlers);
-    }
-    return this;
+    return this.routeHandler('delete', ...args);
   }
 
   public patch(...args: MagicRoutePType<PathSet>): MagicRouteRType<PathSet> {
-    if (this.currentPath) {
-      const [reqAndRes, ...handlers] = args as [
-        RequestAndResponseType,
-        ...MagicMiddleware[],
-      ];
-      this.wrapper('patch', this.currentPath, reqAndRes, ...handlers);
-    } else {
-      const [path, reqAndRes, ...handlers] = args as [
-        string,
-        RequestAndResponseType,
-        ...MagicMiddleware[],
-      ];
-      this.wrapper('patch', path, reqAndRes, ...handlers);
-    }
-    return this;
+    return this.routeHandler('patch', ...args);
   }
 
   public put(...args: MagicRoutePType<PathSet>): MagicRouteRType<PathSet> {
-    if (this.currentPath) {
-      const [reqAndRes, ...handlers] = args as [
-        RequestAndResponseType,
-        ...MagicMiddleware[],
-      ];
-      this.wrapper('put', this.currentPath, reqAndRes, ...handlers);
-    } else {
-      const [path, reqAndRes, ...handlers] = args as [
-        string,
-        RequestAndResponseType,
-        ...MagicMiddleware[],
-      ];
-      this.wrapper('put', path, reqAndRes, ...handlers);
-    }
-    return this;
+    return this.routeHandler('put', ...args);
   }
 
   public use(...args: Parameters<Router['use']>): void {
     this.router.use(...args);
   }
 
-  public route(path: string): MagicRouteRType<true> {
+  public route(path: MagicPathType): MagicRouteRType<true> {
     return new MagicRouter<true>(this.rootRoute, path);
+  }
+
+  private routeHandler(method: Method, ...args: MagicRoutePType<PathSet>) {
+    if (this.currentPath) {
+      const [reqAndRes, ...handlers] = args as [
+        RequestAndResponseType,
+        ...MagicMiddleware[],
+      ];
+      this.wrapper(method, this.currentPath, reqAndRes, ...handlers);
+    } else {
+      const [path, reqAndRes, ...handlers] = args as [
+        MagicPathType,
+        RequestAndResponseType,
+        ...MagicMiddleware[],
+      ];
+      this.wrapper(method, path, reqAndRes, ...handlers);
+    }
+    return this;
   }
 
   // Method to get the router instance


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Implement a `.route` method in the `MagicRouter` class to allow setting a current path, enabling method chaining for HTTP methods and introducing conditional route types to manage path settings.

New Features:
- Introduce a new `.route` method in the `MagicRouter` class to set a current path for subsequent HTTP method calls.

Enhancements:
- Enable method chaining for HTTP methods (`get`, `post`, `delete`, `patch`, `put`) in the `MagicRouter` class.
- Add conditional route types to handle scenarios where a path is set or not set in the `MagicRouter` class.

<!-- Generated by sourcery-ai[bot]: end summary -->